### PR TITLE
Fix GnuPG configuration menu crash and add ECC subkey type

### DIFF
--- a/generic/gnupgplugin/model.cpp
+++ b/generic/gnupgplugin/model.cpp
@@ -97,6 +97,8 @@ QList<QStandardItem*> parseLine(const QString &line)
 	case 1: rows << new QStandardItem("RSA"); break;
 	case 16: rows << new QStandardItem("ELG-E"); break;
 	case 17: rows << new QStandardItem("DSA"); break;
+	case 18: rows << new QStandardItem("ECC"); break;
+	default: rows << new QStandardItem(""); break;
 	}
 
 	// Short ID


### PR DESCRIPTION
There is no default case for key algorithm other than RSA, DSA and elGamal.
Parsing keys of other types result in incomplete "rows" enum filling
which later cause crash in Model::showKeys as could not find Fingerprint field and
row.at(Fingerprint) resulted in NULL pointer.

This commit adds default case and new ECC subkey type.